### PR TITLE
Update simss.pas

### DIFF
--- a/SimSS/simss.pas
+++ b/SimSS/simss.pas
@@ -677,7 +677,12 @@ BEGIN {main program}
 			IF (Vcount MOD par.outputRatio = 0) AND acceptNewSolution 
 				THEN Write_Variables_To_File(curr, stv, par, FALSE);	
 			
-        quit_Voc:=(JVSim[VCount].Jext>0) AND par.untilVoc AND (par.G_frac * stv.Lgen<>0); {only stop past Voc if there is light!}
+	IF par.untilVoc = -1 THEN
+		quit_Voc := (JVSim[VCount].Jext < 0) AND (par.G_frac * stv.Lgen <> 0)
+	ELSE IF par.untilVoc = 0 THEN
+		quit_Voc := FALSE
+	ELSE IF par.untilVoc = 1 THEN
+		quit_Voc := (JVSim[VCount].Jext > 0) AND (par.G_frac * stv.Lgen <> 0);
 
         VCount:=VCount + 1;
     END; {loop over voltages}


### PR DESCRIPTION
If the HTL faces the illumination, with the previous version one cannot use "untilVoc = 1". When using "untilVoc = 1" and "Vscan = -1" in the previous version, at the first point Jext is positive, because the JV curve is drawn from the 2nd to the 3rd quadrant if the HTL faces the illumination. Therefore SIMsalabim quits immediately after the first point.

Note that with this change, Vmpp, MPP, and FF are not correctly determined in the scPars-file if the HTL faces the illumination. This need further improvement.